### PR TITLE
feat: implement portable execvpe

### DIFF
--- a/src/builtin/exec.rs
+++ b/src/builtin/exec.rs
@@ -1,4 +1,5 @@
-use nix::{errno::Errno, unistd::execvpe};
+use nix::{errno::Errno};
+use crate::util::posix_extension::execvpe;
 
 use super::{
   eval::execute::ExecArgs,

--- a/src/eval/execute.rs
+++ b/src/eval/execute.rs
@@ -2,8 +2,9 @@ use std::{collections::VecDeque, ffi::CString, os::unix::fs::PermissionsExt, pat
 
 use nix::{
   errno::Errno,
-  unistd::{ForkResult, Pid, execve, execvpe, fork, isatty, setpgid},
+  unistd::{ForkResult, Pid, execve, fork, isatty, setpgid},
 };
+use crate::util::posix_extension::execvpe;
 use scopeguard::defer;
 use unicode_segmentation::UnicodeSegmentation;
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -5,6 +5,7 @@ mod macros;
 mod pos;
 mod strops;
 mod ui;
+pub mod posix_extension;
 
 use std::os::fd::BorrowedFd;
 

--- a/src/util/posix_extension.rs
+++ b/src/util/posix_extension.rs
@@ -1,0 +1,34 @@
+use std::convert::Infallible;
+use std::ffi::CStr;
+use nix::unistd::execve;
+use nix::errno::Errno;
+
+use crate::Shed;
+
+pub fn execvpe<SA: AsRef<CStr>, SE: AsRef<CStr>>(
+    filename: &CStr,
+    args: &[SA],
+    env: &[SE],
+) -> nix::Result<Infallible> {
+    // for nix::unistd::execve
+    let args_c: Vec<&CStr> = args.iter().map(|a| a.as_ref()).collect();
+    let env_c: Vec<&CStr> = env.iter().map(|e| e.as_ref()).collect();
+
+    if filename.to_bytes().contains(&b'/') {
+        execve(filename, &args_c, &env_c)?;
+    } else {
+        let path = Shed::vars(|v| v.get_var("PATH"));
+        for dir in std::env::split_paths(&path) {
+            let full_path_str = dir.join(filename.to_str().unwrap());
+            let c_path = std::ffi::CString::new(full_path_str.to_str().unwrap()).unwrap();
+            match execve(c_path.as_c_str(), &args_c, &env_c) {
+                Ok(_) => unreachable!(),
+                Err(Errno::ENOENT) | Err(Errno::ENOTDIR) => continue, // Try next path
+                Err(e) => return Err(e), // Permission denied or other error
+            }
+        }
+    }
+
+    // Not found
+    Err(Errno::ENOENT)
+}


### PR DESCRIPTION
I implemented a more portable version of a GNU extension function `execvpe` by manually search for PATH and call `execve`.