### PR TITLE
feat: add new autocmd 'on-command-not-found'

### DIFF
--- a/doc/autocmd.txt
+++ b/doc/autocmd.txt
@@ -39,6 +39,13 @@ behavior without modifying the shell itself.
 
       Fires after a command finishes.
 
+  `on-command-not-found`                       *autocmd-on-command-not-found*
+
+      Fires if the command is not found.
+
+      Special variables:
+        `$CMD`        the command name that is not found
+
   2.2 Directory Changes                        *autocmd-dir-events*
 
   `pre-change-dir`                             *autocmd-pre-change-dir*

--- a/doc/builtin.txt
+++ b/doc/builtin.txt
@@ -194,6 +194,7 @@ AUTOCMD                                          *builtin-autocmd* *autocmd*
 
     `pre-cmd`               before a command is executed
     `post-cmd`              after a command completes
+    `on-command-not-found`  when command not found
     `pre-change-dir`        before `cd` changes the directory
     `post-change-dir`       after `cd` changes the directory
     `on-job-finish`         when a background job finishes

--- a/src/eval/execute.rs
+++ b/src/eval/execute.rs
@@ -1,6 +1,9 @@
+use crate::autocmd;
 use std::{collections::VecDeque, ffi::CString, os::unix::fs::PermissionsExt, path::Path, rc::Rc};
 
+use crate::state::util::with_vars;
 use crate::util::posix_extension::execvpe;
+
 use nix::{
   errno::Errno,
   unistd::{ForkResult, Pid, execve, fork, isatty, setpgid},
@@ -1140,6 +1143,9 @@ impl Dispatcher {
           sherr!(NotFound @ span, "command not found")
             .with_context(context)
             .print_error();
+          with_vars([("CMD".into(), cmd.to_str().unwrap_or_default())], || {
+            autocmd!(OnCommandNotFound)
+          });
 
           unsafe { nix::libc::_exit(127) };
         }

--- a/src/state/logic.rs
+++ b/src/state/logic.rs
@@ -79,6 +79,7 @@ pub(crate) enum AutoCmdKind {
   OnScreensaverReturn,
   OnTimeReport,
   OnExit,
+  OnCommandNotFound,
 }
 
 crate::two_way_display!(AutoCmdKind,
@@ -101,6 +102,7 @@ crate::two_way_display!(AutoCmdKind,
   OnScreensaverReturn <=> "on-screensaver-return";
   OnTimeReport        <=> "on-time-report";
   OnExit              <=> "on-exit";
+  OnCommandNotFound   <=> "on-command-not-found";
 );
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
This PR adds a new `autocmd` hook for Not Found error, this allow users to hook `command-not-found` to suggest packages in the distro index.

```
~/gitrepo/shed/
$ autocmd on-command-not-found 'command-not-found $CMD'

~/gitrepo/shed/
$ ewja

Error: Not Found
   ╭─[ <stdin>:1:1 ]
   │
 1 │ ewja
   │ ──┬─
   │   ╰─── command not found
───╯
No command ewja found, did you mean:
 Command eja in package eja
```