### PR TITLE
doc: update flog entry in builtin.txt

### DIFF
--- a/doc/builtin.txt
+++ b/doc/builtin.txt
@@ -702,7 +702,7 @@ FC                                               *builtin-fc* *fc*
       `fc -e vim`               edit last command in vim
 
 ==============================================================================
-FLOG                                             *builtin-flog* *flog*
+FLOG                       *builtin-flog* *flog* *FLOG_FMT* *flog-fmt*
 
   `flog [-p {prefix}] {level} {message} ...`
 
@@ -734,22 +734,30 @@ FLOG                                             *builtin-flog* *flog*
 
       Any strftime format code accepted by chrono is valid.
 
-  The `SHED_LOG` environment variable controls the minimum level that
-  produces output. A call whose level is below `SHED_LOG` is silently
+  The `FERN_LOG` environment variable controls the minimum level that
+  produces output. A call whose level is below `FERN_LOG` is silently
   suppressed. This allows scripts to emit `debug` or `trace` calls that
   are invisible by default and enabled on demand.
   The hierarchy is as follows:
 
         `none` > `error` > `warn` > `info` > `debug` > `trace`.
 
-  A `SHED_LOG` value of `none` suppresses all log messages.
+  A `FERN_LOG` value of `none` suppresses all log messages.
+
+  The `FLOG_FMT` environment variable sets the default prefix format
+  used when `-p` is not specified. The `-p` flag takes precedence
+  over `FLOG_FMT` if both are present. If neither is set, the prefix
+  defaults to `[{level}]`. Useful for setting a project-wide log
+  format once in `.shedrc` rather than passing `-p` to every call.
 
   Examples:
 
       `flog info "starting up"`
       `flog -p '[%H:%M:%S {level}]' warn "disk usage high"`
       `flog -p '[{level} {source}:{line}]' error "unexpected value"`
-      `SHED_LOG=debug flog debug "entering loop"`
+      `FERN_LOG=debug flog debug "entering loop"`
+      `FLOG_FMT='[%H:%M:%S {level}]' flog info "started"`
+      `export FLOG_FMT='[{level} {source}:{line}]'  # in .shedrc`
 
 ==============================================================================
 GETOPTS                                          *builtin-getopts* *getopts*


### PR DESCRIPTION
The entry for the `flog` builtin is still referring to the old `SHED_LOG` variable instead of the `FLOG_LEVEL` variable. It is also missing info on the `FLOG_FMT` variable.

Closes #13 