### PR TITLE
fixed the prompt being drawn twice when the welcome message is printed

### DIFF
--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -72,7 +72,9 @@ fn handle_signals_interactive(readline: &mut ShedLine) -> ShResult<bool> {
     readline.prompt_mut().refresh();
   }
 
-  readline.print_line(false)?;
+  if readline.needs_redraw() {
+    readline.print_line(false)?;
+  }
 
   Ok(true)
 }

--- a/src/readline/mod.rs
+++ b/src/readline/mod.rs
@@ -1525,6 +1525,10 @@ impl ShedLine {
         && !cmd.flags.contains(CmdFlags::IS_SUBMIT)
   }
 
+  pub fn needs_redraw(&self) -> bool {
+    self.needs_redraw
+  }
+
   pub fn print_line(&mut self, final_draw: bool) -> ShResult<()> {
     let _sync = SyncOutputGuard::begin();
     if self.statline.is_some() && !shopt!(statline.enable) {


### PR DESCRIPTION
`handle_signals_interactive` unconditionally calls `readline.print_line(false)`. This causes the prompt to render twice when the status line is disabled.

Closes #14 