### PR TITLE
fix: escaped single quotes now properly handled by the lexer

### DIFF
--- a/src/eval/lex/mod.rs
+++ b/src/eval/lex/mod.rs
@@ -928,7 +928,7 @@ impl LexStream {
           pos += ch.len_utf8()
         }
       }
-      '\\' => {
+      '\\' if !self.quote_state.in_single() => {
         pos += 1;
         if let Some(ch) = chars.next() {
           pos += ch.len_utf8();
@@ -941,6 +941,23 @@ impl LexStream {
                 break;
               }
             }
+          }
+        }
+      }
+      '$' if !self.quote_state.in_single() && chars.peek() == Some(&'\'') => {
+        pos += 1;        // '$'
+        chars.next();    // consume opening '
+        pos += 1;
+        // this needs its own branch
+        // because escaping a single quote in $'...' is valid
+        while let Some(c) = chars.next() {
+          pos += c.len_utf8();
+          if c == '\\' {
+            if let Some(esc) = chars.next() {
+              pos += esc.len_utf8();
+            }
+          } else if c == '\'' {
+            break;
           }
         }
       }

--- a/src/tests/posix.rs
+++ b/src/tests/posix.rs
@@ -390,6 +390,8 @@ mod quoting_2_2 {
       squote_idiom            : r#"echo 'foo'\''bar'"# => "foo'bar\n";
       squote_backslash        : r#"echo 'a\b'"#        => "a\\b\n";
       squote_double_backslash : r#"echo 'a\\b'"#       => "a\\\\b\n";
+      squote_backslash_does_not_escape_quote :
+                                 r#"echo 'foo\' bar"#  => "foo\\ bar\n";
       squote_amp              : r#"echo 'a&b'"#        => "a&b\n";
       squote_semi             : r#"echo 'a;b'"#        => "a;b\n";
       squote_lt               : r#"echo 'a<b'"#        => "a<b\n";


### PR DESCRIPTION
Title.

Closes #29 