### PR TITLE
feat: use the XDG Base Directory specification by default for runtime files

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -142,6 +142,7 @@ mod dispatch_input_tests {
       stdin,
       login_shell: false,
       welcome: false,
+      rc_path: None,
       no_rc: true,
       set: vec![],
       edit_script: false,

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -14,6 +14,7 @@ use super::{
     self,
     logic::TrapTarget,
     util::{self, generate_default_rc, source_env},
+    vars::{VarFlags, VarKind},
   },
   status_msg, try_var,
   util::flog,
@@ -57,6 +58,10 @@ pub(super) struct ShedArgs {
   /// Skip sourcing runtime command files
   #[arg(long)]
   pub(super) no_rc: bool,
+
+  /// Provide the path to the runtime commands file
+  #[arg(long)]
+  pub(super) rc_path: Option<String>,
 
   /// List of POSIX 'set' options to enable
   #[arg(short = 'o', value_name = "OPTION", value_parser = Self::SET_OPTS)]
@@ -111,10 +116,13 @@ pub(super) fn setup() -> Option<ShedArgs> {
     return None;
   }
 
-  if !args.no_rc
-    && let Err(e) = source_env()
-  {
-    e.print_error();
+  if !args.no_rc {
+    if let Some(ref path) = args.rc_path {
+      Shed::vars_mut(|v| v.set_var("SHED_RC", VarKind::Str(path.clone()), VarFlags::EXPORT)).ok();
+    }
+    if let Err(e) = source_env() {
+      e.print_error();
+    }
   }
 
   for set_opt in &args.set {

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -22,7 +22,10 @@ use super::{
   keys::KeyEvent,
   procio::MIN_INTERNAL_FD,
   sherr,
-  state::vars::{VarFlags, VarKind},
+  state::{
+    self,
+    vars::{VarFlags, VarKind},
+  },
   status_msg, system_msg,
   util::{Pos, ShErr},
   var,
@@ -311,15 +314,13 @@ pub(crate) struct ShedSocket {
 }
 
 impl ShedSocket {
-  pub fn dir() -> String {
-    std::env::var("XDG_RUNTIME_DIR")
-      .or_else(|_| std::env::var("TMPDIR"))
-      .unwrap_or_else(|_| format!("/tmp/shed-{}", nix::unistd::getuid()))
-  }
   pub fn path() -> String {
     let pid = Pid::this();
-    let runtime_dir = Self::dir();
-    format!("{runtime_dir}/shed/{pid}.sock")
+    state::util::xdg_runtime_dir()
+      .join("shed")
+      .join(format!("{pid}.sock"))
+      .display()
+      .to_string()
   }
   pub fn mode() -> Mode {
     var!("SHED_SOCK_MODE")
@@ -329,10 +330,12 @@ impl ShedSocket {
       .unwrap_or(Mode::S_IRUSR | Mode::S_IWUSR)
   }
   pub fn new() -> ShResult<Self> {
-    let runtime_dir = Self::dir();
-    std::fs::create_dir_all(format!("{runtime_dir}/shed"))?;
+    let sock_dir = state::util::xdg_runtime_dir().join("shed");
 
-    let sock_path = Self::path();
+    std::fs::create_dir_all(&sock_dir)?;
+
+    let pid = Pid::this();
+    let sock_path = sock_dir.join(format!("{pid}.sock"));
     std::fs::remove_file(&sock_path).ok();
 
     let listener = UnixListener::bind(&sock_path)?;
@@ -361,7 +364,7 @@ impl ShedSocket {
     Shed::vars_mut(|v| {
       v.set_var(
         "SHED_SOCK",
-        VarKind::Str(sock_path.clone()),
+        VarKind::Str(sock_path.display().to_string()),
         VarFlags::EXPORT,
       )
     })
@@ -369,7 +372,7 @@ impl ShedSocket {
     Ok(Self {
       listener,
       pid: Pid::this(),
-      path: PathBuf::from(sock_path),
+      path: sock_path,
     })
   }
   pub fn listener(&self) -> &UnixListener {

--- a/src/state/terminal/mod.rs
+++ b/src/state/terminal/mod.rs
@@ -333,29 +333,21 @@ impl Terminal {
 
   pub fn query_term_caps(&mut self) -> ShResult<()> {
     if self.test_mode {
-      log::debug!("query_term_caps: test_mode set, skipping probe");
       return Ok(());
     }
     let Some(tty) = self.tty() else {
-      log::debug!("query_term_caps: no tty, skipping probe");
       return Ok(());
     };
     let mut caps = TermCap::empty();
-    log::debug!(
-      "query_term_caps: sending capability burst ({} bytes)",
-      Self::CAP_BURST.len()
-    );
     self.write_direct(Self::CAP_BURST)?;
 
     let deadline = Instant::now() + Duration::from_secs(2);
     'outer: while Instant::now() < deadline {
       let remaining = deadline.saturating_duration_since(Instant::now());
       let Ok(timeout) = PollTimeout::try_from(remaining) else {
-        log::trace!("query_term_caps: timeout conversion failed, exiting loop");
         break;
       };
       if self.poll(timeout)? == 0 {
-        log::debug!("query_term_caps: poll timeout reached, exiting loop");
         break;
       }
 
@@ -363,32 +355,25 @@ impl Terminal {
 
       match_loop!(self.reader.read_event()? => event, {
         TermEvent::KittyKbdFlags => {
-          log::debug!("query_term_caps: kitty keyboard protocol supported");
           self.term_caps.insert(TermCap::KITTY_KBD_PROTO);
         }
         TermEvent::Capabilities { name, .. } => match name.as_str() {
           "RGB" => {
-            log::debug!("query_term_caps: TRUECOLOR supported");
             caps.insert(TermCap::TRUECOLOR);
           }
           "Su" => {
-            log::debug!("query_term_caps: SYNC_OUTPUT supported");
             caps.insert(TermCap::SYNC_OUTPUT);
           }
           _ => {
-            log::trace!("query_term_caps: unrecognized cap name {name:?}");
           }
         }
         TermEvent::XtVersion(ver) => {
-          log::debug!("query_term_caps: recording xt_version={ver:?}");
           self.xt_version = Some(ver);
         }
         TermEvent::PrimaryDevAttr => {
-          log::debug!("query_term_caps: found DA1");
           break 'outer
         }
         other => {
-          log::trace!("query_term_caps: ignoring event {other:?}");
         }
       });
     }
@@ -396,18 +381,11 @@ impl Terminal {
     if let Some(val) = try_var!("COLORTERM")
       && matches!(val.as_str(), "truecolor" | "24bit")
     {
-      log::debug!("query_term_caps: COLORTERM environment variable indicates truecolor support");
       caps.insert(TermCap::TRUECOLOR);
     }
 
     self.term_caps |= caps;
 
-    log::debug!(
-      "query_term_caps: complete (term_caps={:?}, local_caps={:?}, xt_version={:?})",
-      self.term_caps,
-      caps,
-      self.xt_version
-    );
     Ok(())
   }
 
@@ -688,7 +666,6 @@ impl Terminal {
     )?;
 
     if let Err(e) = result {
-      log::error!("Failed to set terminal process group: {e}");
       tcsetpgrp(tty, getpgrp())?;
     }
 

--- a/src/state/terminal/mod.rs
+++ b/src/state/terminal/mod.rs
@@ -373,8 +373,7 @@ impl Terminal {
         TermEvent::PrimaryDevAttr => {
           break 'outer
         }
-        other => {
-        }
+        _ => {}
       });
     }
 
@@ -665,7 +664,7 @@ impl Terminal {
       Some(&mut new_mask),
     )?;
 
-    if let Err(e) = result {
+    if result.is_err() {
       tcsetpgrp(tty, getpgrp())?;
     }
 

--- a/src/state/terminal/parse.rs
+++ b/src/state/terminal/parse.rs
@@ -185,7 +185,6 @@ impl EventParser {
 
   pub fn parse_term_cap(&mut self) {
     let Some(buf) = self.dcs_buf.take() else {
-      log::trace!("parse_term_cap: no dcs_buf, skipping");
       return;
     };
     let supported = self.dcs_supported;
@@ -194,7 +193,6 @@ impl EventParser {
 
     // Only emit when the terminal reported the cap as supported.
     if !supported {
-      log::debug!("XTGETTCAP response: cap unsupported (raw={buf:?})");
       return;
     }
 
@@ -203,23 +201,19 @@ impl EventParser {
       None => (buf.as_str(), None),
     };
     let Some(name) = Self::decode_hex(name_hex) else {
-      log::debug!("XTGETTCAP response: failed to decode name hex {name_hex:?}");
       return;
     };
     let _value = value_hex.and_then(Self::decode_hex);
 
-    log::debug!("XTGETTCAP response: name={name:?} value={_value:?}");
     self.push(TermEvent::Capabilities { name, _value });
   }
 
   pub fn parse_xtversion(&mut self) {
     let Some(buf) = self.dcs_buf.take() else {
-      log::trace!("parse_xtversion: no dcs_buf, skipping");
       return;
     };
     self.dcs_kind = None;
     let xtver = XtVersion::parse(&buf);
-    log::debug!("XTVERSION response: raw={buf:?} parsed={xtver:?}");
     self.push(TermEvent::XtVersion(xtver));
   }
 
@@ -244,7 +238,6 @@ impl EventParser {
 impl vte::Perform for EventParser {
   #[allow(clippy::single_match)]
   fn hook(&mut self, params: &vte::Params, intermediates: &[u8], _ignore: bool, action: char) {
-    log::trace!("DCS hook: params={params:?}, intermediates={intermediates:?}, action={action:?}");
     let params: Vec<u16> = params
       .iter()
       .map(|p| p.first().copied().unwrap_or(0))
@@ -257,20 +250,13 @@ impl vte::Perform for EventParser {
         self.dcs_kind = Some(DcsKind::XtGetCap);
 
         self.dcs_buf = Some(String::new());
-        log::trace!(
-          "DCS hook: XTGETTCAP introducer (supported={})",
-          self.dcs_supported
-        );
       }
       ([b'>'], '|') => {
         self.dcs_kind = Some(DcsKind::XtVersion);
         self.dcs_buf = Some(String::new());
-        log::trace!("DCS hook: XTVERSION introducer");
       }
 
-      _ => {
-        log::trace!("DCS hook: unrecognized introducer ({intermediates:?}, {action:?})");
-      }
+      _ => {}
     }
   }
 
@@ -353,7 +339,6 @@ impl vte::Perform for EventParser {
   }
 
   fn execute(&mut self, byte: u8) {
-    log::trace!("execute: {byte:#04x}");
     if let Some(buf) = self.paste_buf.as_mut() {
       buf.push(byte as char);
       return;
@@ -382,9 +367,6 @@ impl vte::Perform for EventParser {
     _ignore: bool,
     action: char,
   ) {
-    log::trace!(
-      "CSI dispatch: params={params:?}, intermediates={intermediates:?}, action={action:?}"
-    );
     let params: Vec<u16> = params
       .iter()
       .map(|p| p.first().copied().unwrap_or(0))
@@ -526,8 +508,7 @@ impl vte::Perform for EventParser {
     self.push(event);
   }
 
-  fn esc_dispatch(&mut self, intermediates: &[u8], _ignore: bool, byte: u8) {
-    log::trace!("ESC dispatch: intermediates={intermediates:?}, byte={byte:#04x}");
+  fn esc_dispatch(&mut self, _intermediates: &[u8], _ignore: bool, byte: u8) {
     // SS3 sequences
     if byte == b'O' {
       self.ss3_pending = true;

--- a/src/state/util.rs
+++ b/src/state/util.rs
@@ -268,9 +268,18 @@ pub fn try_hash() {
 }
 
 pub fn rc_file_path() -> Option<PathBuf> {
-  try_var!("SHED_RC")
-    .map(PathBuf::from)
-    .or_else(|| get_home().map(|home| home.join(".shedrc")))
+  if let Some(p) = try_var!("SHED_RC") {
+    return Some(PathBuf::from(p));
+  }
+  let xdg = xdg_config_home().map(|c| c.join("shed").join("shedrc"));
+  let home = get_home().map(|h| h.join(".shedrc"));
+
+  xdg
+    .as_ref()
+    .filter(|p| p.is_file())
+    .cloned()
+    .or_else(|| home.as_ref().filter(|p| p.is_file()).cloned())
+    .or(xdg)
 }
 
 pub fn generate_default_rc() -> ShResult<Option<PathBuf>> {
@@ -279,6 +288,10 @@ pub fn generate_default_rc() -> ShResult<Option<PathBuf>> {
   if rc_path.exists() {
     return Ok(None);
   }
+  if let Some(parent) = rc_path.parent() {
+    std::fs::create_dir_all(parent)?;
+  };
+
   log::info!("Generating default rc file at {}", rc_path.display());
   let mut rc_file = OpenOptions::new()
     .write(true)
@@ -337,19 +350,25 @@ pub fn source_runtime_file(name: &str, env_var_name: Option<&str>) -> ShResult<(
     e.print_error();
   }
 
-  let path = if let Some(name) = env_var_name
-    && let Some(path) = try_var!(name)
+  let user_path = if let Some(n) = env_var_name
+    && let Some(p) = try_var!(n)
   {
-    PathBuf::from(&path)
-  } else if let Some(home) = get_home() {
-    home.join(format!(".{name}"))
+    Some(PathBuf::from(p))
   } else {
-    return Err(sherr!(InternalErr, "could not determine home path",));
+    xdg_config_home()
+      .map(|c| c.join("shed").join(name))
+      .filter(|p| p.is_file())
+      .or_else(|| {
+        get_home()
+          .map(|h| h.join(format!(".{name}")))
+          .filter(|p| p.is_file())
+      })
   };
-  if !path.is_file() {
-    return Ok(());
+
+  match user_path {
+    Some(path) if path.is_file() => source_file(path),
+    _ => Ok(()),
   }
-  source_file(path)
 }
 
 pub fn source_rc() -> ShResult<()> {
@@ -504,6 +523,22 @@ pub fn get_default_path() -> Option<String> {
   }
 }
 
+pub fn xdg_runtime_dir() -> PathBuf {
+  if let Some(p) = try_var!("XDG_RUNTIME_DIR") {
+    return PathBuf::from(p);
+  }
+  if let Some(p) = try_var!("TMPDIR") {
+    return PathBuf::from(p);
+  }
+  PathBuf::from(format!("/tmp/shed-{}", getuid()))
+}
+
+pub fn xdg_config_home() -> Option<PathBuf> {
+  try_var!("XDG_CONFIG_HOME")
+    .map(PathBuf::from)
+    .or_else(|| get_home().map(|home| home.join(".config")))
+}
+
 pub fn get_home() -> Option<PathBuf> {
   try_var!("HOME")
     .map(PathBuf::from)
@@ -556,6 +591,135 @@ pub fn get_exec_wrappers() -> Vec<String> {
   wrappers.extend(user_wrappers);
 
   wrappers
+}
+
+#[cfg(test)]
+mod xdg_resolver_tests {
+  use super::*;
+  use crate::state::vars::{VarFlags, VarKind};
+  use crate::tests::testutil::TestGuard;
+
+  fn set_var(name: &str, val: &str) {
+    Shed::vars_mut(|v| {
+      v.set_var(name, VarKind::Str(val.into()), VarFlags::EXPORT)
+        .unwrap();
+    });
+  }
+  fn unset_var(name: &str) {
+    Shed::vars_mut(|v| {
+      v.unset_var(name).ok();
+    });
+  }
+
+  // ─── xdg_config_home ──────────────────────────────────────────────
+
+  #[test]
+  fn xdg_config_home_uses_env_var_when_set() {
+    let _g = TestGuard::new();
+    set_var("XDG_CONFIG_HOME", "/explicit/xdg/config");
+    assert_eq!(
+      xdg_config_home(),
+      Some(PathBuf::from("/explicit/xdg/config"))
+    );
+  }
+
+  #[test]
+  fn xdg_config_home_falls_back_to_home_dot_config() {
+    let _g = TestGuard::new();
+    unset_var("XDG_CONFIG_HOME");
+    set_var("HOME", "/some/home");
+    assert_eq!(xdg_config_home(), Some(PathBuf::from("/some/home/.config")));
+  }
+
+  // ─── xdg_runtime_dir ──────────────────────────────────────────────
+
+  #[test]
+  fn xdg_runtime_dir_prefers_env_var() {
+    let _g = TestGuard::new();
+    set_var("XDG_RUNTIME_DIR", "/run/user/1000");
+    assert_eq!(xdg_runtime_dir(), PathBuf::from("/run/user/1000"));
+  }
+
+  #[test]
+  fn xdg_runtime_dir_falls_back_to_tmpdir() {
+    let _g = TestGuard::new();
+    unset_var("XDG_RUNTIME_DIR");
+    set_var("TMPDIR", "/custom/tmp");
+    assert_eq!(xdg_runtime_dir(), PathBuf::from("/custom/tmp"));
+  }
+
+  #[test]
+  fn xdg_runtime_dir_falls_back_to_tmp_uid_when_none_set() {
+    let _g = TestGuard::new();
+    unset_var("XDG_RUNTIME_DIR");
+    unset_var("TMPDIR");
+    let expected = PathBuf::from(format!("/tmp/shed-{}", getuid()));
+    assert_eq!(xdg_runtime_dir(), expected);
+  }
+
+  // ─── rc_file_path ─────────────────────────────────────────────────
+
+  #[test]
+  fn rc_file_path_shed_rc_env_var_overrides_everything() {
+    let _g = TestGuard::new();
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("explicit.rc");
+    std::fs::write(&path, "").unwrap();
+    set_var("SHED_RC", &path.to_string_lossy());
+
+    // Even with XDG file present, SHED_RC wins
+    let xdg_dir = tempfile::TempDir::new().unwrap();
+    set_var("XDG_CONFIG_HOME", &xdg_dir.path().to_string_lossy());
+    std::fs::create_dir_all(xdg_dir.path().join("shed")).unwrap();
+    std::fs::write(xdg_dir.path().join("shed").join("shedrc"), "").unwrap();
+
+    assert_eq!(rc_file_path(), Some(path));
+  }
+
+  #[test]
+  fn rc_file_path_prefers_xdg_over_legacy_when_both_exist() {
+    let _g = TestGuard::new();
+    unset_var("SHED_RC");
+    let home = tempfile::TempDir::new().unwrap();
+    let xdg = tempfile::TempDir::new().unwrap();
+    set_var("HOME", &home.path().to_string_lossy());
+    set_var("XDG_CONFIG_HOME", &xdg.path().to_string_lossy());
+
+    std::fs::write(home.path().join(".shedrc"), "").unwrap();
+    std::fs::create_dir_all(xdg.path().join("shed")).unwrap();
+    let xdg_rc = xdg.path().join("shed").join("shedrc");
+    std::fs::write(&xdg_rc, "").unwrap();
+
+    assert_eq!(rc_file_path(), Some(xdg_rc));
+  }
+
+  #[test]
+  fn rc_file_path_falls_back_to_legacy_when_xdg_does_not_exist() {
+    let _g = TestGuard::new();
+    unset_var("SHED_RC");
+    let home = tempfile::TempDir::new().unwrap();
+    let xdg = tempfile::TempDir::new().unwrap();
+    set_var("HOME", &home.path().to_string_lossy());
+    set_var("XDG_CONFIG_HOME", &xdg.path().to_string_lossy());
+
+    let legacy = home.path().join(".shedrc");
+    std::fs::write(&legacy, "").unwrap();
+
+    assert_eq!(rc_file_path(), Some(legacy));
+  }
+
+  #[test]
+  fn rc_file_path_returns_xdg_path_for_creation_when_neither_exists() {
+    let _g = TestGuard::new();
+    unset_var("SHED_RC");
+    let home = tempfile::TempDir::new().unwrap();
+    let xdg = tempfile::TempDir::new().unwrap();
+    set_var("HOME", &home.path().to_string_lossy());
+    set_var("XDG_CONFIG_HOME", &xdg.path().to_string_lossy());
+
+    let expected = xdg.path().join("shed").join("shedrc");
+    assert_eq!(rc_file_path(), Some(expected));
+  }
 }
 
 #[cfg(test)]
@@ -640,6 +804,20 @@ mod generate_default_rc_tests {
     assert!(content.contains("keymap"), "got: {content:?}");
   }
 
+  #[test]
+  fn creates_parent_dir_when_missing() {
+    let _g = TestGuard::new();
+    let dir = tempfile::TempDir::new().unwrap();
+    // Nested path whose parent directories don't exist yet
+    let rc = dir.path().join("nested").join("shed").join("shedrc");
+    assert!(!rc.parent().unwrap().exists());
+    set_rc_path(&rc);
+    let result = generate_default_rc().unwrap();
+    assert_eq!(result, Some(rc.clone()));
+    assert!(rc.exists());
+    assert!(rc.parent().unwrap().is_dir());
+  }
+
   // The "no rc path resolvable" error path is essentially unreachable
   // in practice: `get_home` falls back to passwd-uid lookup, so even
   // with HOME unset rc_file_path returns Some. Not tested here.
@@ -699,6 +877,78 @@ mod source_runtime_file_tests {
     Shed::vars_mut(|v| v.unset_var("ENV_NAME_NOT_SET").ok());
     source_runtime_file("my_test_rc", Some("ENV_NAME_NOT_SET")).unwrap();
     assert_eq!(var!("HOME_FALLBACK_MARKER"), "via_home");
+  }
+
+  #[test]
+  fn prefers_xdg_over_legacy_when_both_exist() {
+    let _g = TestGuard::new();
+    let home = tempfile::TempDir::new().unwrap();
+    let xdg = tempfile::TempDir::new().unwrap();
+    set_var("HOME", &home.path().to_string_lossy());
+    set_var("XDG_CONFIG_HOME", &xdg.path().to_string_lossy());
+    Shed::vars_mut(|v| v.unset_var("XDG_OVER_LEGACY_ENV").ok());
+
+    // legacy ~/.over_legacy_rc
+    std::fs::write(
+      home.path().join(".over_legacy_rc"),
+      "OVER_LEGACY_SRC=legacy\n",
+    )
+    .unwrap();
+    // xdg ~/.config/shed/over_legacy_rc
+    std::fs::create_dir_all(xdg.path().join("shed")).unwrap();
+    std::fs::write(
+      xdg.path().join("shed").join("over_legacy_rc"),
+      "OVER_LEGACY_SRC=xdg\n",
+    )
+    .unwrap();
+
+    source_runtime_file("over_legacy_rc", Some("XDG_OVER_LEGACY_ENV")).unwrap();
+    assert_eq!(var!("OVER_LEGACY_SRC"), "xdg");
+  }
+
+  #[test]
+  fn uses_xdg_when_only_it_exists() {
+    let _g = TestGuard::new();
+    let home = tempfile::TempDir::new().unwrap();
+    let xdg = tempfile::TempDir::new().unwrap();
+    set_var("HOME", &home.path().to_string_lossy());
+    set_var("XDG_CONFIG_HOME", &xdg.path().to_string_lossy());
+    Shed::vars_mut(|v| v.unset_var("XDG_ONLY_ENV").ok());
+
+    std::fs::create_dir_all(xdg.path().join("shed")).unwrap();
+    std::fs::write(
+      xdg.path().join("shed").join("xdg_only_rc"),
+      "XDG_ONLY_MARKER=from_xdg\n",
+    )
+    .unwrap();
+
+    source_runtime_file("xdg_only_rc", Some("XDG_ONLY_ENV")).unwrap();
+    assert_eq!(var!("XDG_ONLY_MARKER"), "from_xdg");
+  }
+
+  #[test]
+  fn env_var_overrides_both_xdg_and_legacy() {
+    let _g = TestGuard::new();
+    let home = tempfile::TempDir::new().unwrap();
+    let xdg = tempfile::TempDir::new().unwrap();
+    let explicit_dir = tempfile::TempDir::new().unwrap();
+    set_var("HOME", &home.path().to_string_lossy());
+    set_var("XDG_CONFIG_HOME", &xdg.path().to_string_lossy());
+
+    // All three locations have a file; env-var wins
+    std::fs::write(home.path().join(".triple_rc"), "TRIPLE_SRC=legacy\n").unwrap();
+    std::fs::create_dir_all(xdg.path().join("shed")).unwrap();
+    std::fs::write(
+      xdg.path().join("shed").join("triple_rc"),
+      "TRIPLE_SRC=xdg\n",
+    )
+    .unwrap();
+    let explicit = explicit_dir.path().join("explicit_rc");
+    std::fs::write(&explicit, "TRIPLE_SRC=explicit\n").unwrap();
+    set_var("TRIPLE_RC_ENV", &explicit.to_string_lossy());
+
+    source_runtime_file("triple_rc", Some("TRIPLE_RC_ENV")).unwrap();
+    assert_eq!(var!("TRIPLE_SRC"), "explicit");
   }
 }
 

--- a/src/state/vars.rs
+++ b/src/state/vars.rs
@@ -657,12 +657,6 @@ impl VarTab {
         .map(|c| PathBuf::from(c).join("shed").join("shedrc"))
         .unwrap_or_else(|| PathBuf::from(format!("{resolved_home}/.config/shed/shedrc")));
 
-      log::info!(
-        "init_env: shed_rc={}, SHED_RC={}",
-        shed_rc.display(),
-        std::env::var("SHED_RC").unwrap_or_default()
-      );
-
       resolve("TMPDIR", "/tmp");
       resolve("TERM", &term);
       resolve("LANG", "en_US.UTF-8");
@@ -686,9 +680,6 @@ impl VarTab {
     let mut vars = vec![];
     for (key, val) in std::env::vars() {
       if !vars.iter().any(|(k, _)| k == &key) {
-        if key == "SHED_RC" {
-          log::info!("init_env: found SHED_RC in environment: {}", val);
-        }
         vars.push((key, Var::env_var(&val)));
       }
     }

--- a/src/state/vars.rs
+++ b/src/state/vars.rs
@@ -20,6 +20,9 @@ use super::{
   util::get_separator,
 };
 
+/// a `std::sync::Once` that makes sure we only call VarTab::init_env() once.
+static ENV_INIT: std::sync::Once = std::sync::Once::new();
+
 /// Display key/value pairs as '{key}={value}\n'
 ///
 /// The 'value' is escaped in such a way that the whole line can be reused as a shell assignment
@@ -598,80 +601,97 @@ impl VarTab {
     vars
   }
   fn init_env() -> Vec<(String, Var)> {
+    // The closure below runs exactly one time.
+    // if we spawn any new threads, this won't happen again.
+    ENV_INIT.call_once(|| {
+      let pathbuf_to_string =
+        |pb: Result<PathBuf, std::io::Error>| pb.unwrap_or_default().to_string_lossy().to_string();
+      // First, inherit any env vars from the parent process
+      let term = {
+        if isatty(stdin_fileno()).unwrap_or_default() {
+          if let Ok(term) = std::env::var("TERM") {
+            term
+          } else {
+            "linux".to_string()
+          }
+        } else {
+          "xterm-256color".to_string()
+        }
+      };
+      let home_fallback;
+      let username_fallback;
+      let uid;
+      if let Some(user) = User::from_uid(nix::unistd::Uid::current()).ok().flatten() {
+        home_fallback = user.dir;
+        username_fallback = user.name;
+        uid = user.uid;
+      } else {
+        home_fallback = PathBuf::new();
+        username_fallback = "unknown".into();
+        uid = 0.into();
+      }
+      let home_fallback = pathbuf_to_string(Ok(home_fallback));
+      let hostname = gethostname()
+        .map(|hname| hname.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+      let resolve = |var: &str, fallback: &str| -> String {
+        let val = std::env::var(var).unwrap_or_else(|_| fallback.to_string());
+
+        unsafe { std::env::set_var(var, &val) };
+        val
+      };
+
+      let resolved_home = resolve("HOME", &home_fallback);
+      let resolved_user = resolve("USER", &username_fallback);
+
+      let mut data_dir = std::env::var("XDG_DATA_HOME")
+        .ok()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(format!("{resolved_home}/.local/share")));
+      data_dir.push("shed");
+
+      let shed_db = data_dir.join("shed_hist.db");
+      let shed_rc = std::env::var("XDG_CONFIG_HOME")
+        .ok()
+        .map(|c| PathBuf::from(c).join("shed").join("shedrc"))
+        .unwrap_or_else(|| PathBuf::from(format!("{resolved_home}/.config/shed/shedrc")));
+
+      log::info!(
+        "init_env: shed_rc={}, SHED_RC={}",
+        shed_rc.display(),
+        std::env::var("SHED_RC").unwrap_or_default()
+      );
+
+      resolve("TMPDIR", "/tmp");
+      resolve("TERM", &term);
+      resolve("LANG", "en_US.UTF-8");
+      resolve("LOGNAME", &resolved_user);
+      resolve("PWD", &pathbuf_to_string(std::env::current_dir()));
+      resolve("OLDPWD", &pathbuf_to_string(std::env::current_dir()));
+      resolve("SHELL", &pathbuf_to_string(std::env::current_exe()));
+      resolve("SHED_HISTDB", &shed_db.display().to_string());
+      resolve("SHED_RC", &shed_rc.display().to_string());
+
+      let set_var = |var: &str, val: &str| {
+        unsafe { std::env::set_var(var, val) };
+      };
+
+      set_var("IFS", " \t\n");
+      set_var("UID", &uid.to_string());
+      set_var("PPID", &getppid().to_string());
+      set_var("HOST", &hostname.clone());
+    });
+
     let mut vars = vec![];
     for (key, val) in std::env::vars() {
       if !vars.iter().any(|(k, _)| k == &key) {
+        if key == "SHED_RC" {
+          log::info!("init_env: found SHED_RC in environment: {}", val);
+        }
         vars.push((key, Var::env_var(&val)));
       }
     }
-    let pathbuf_to_string =
-      |pb: Result<PathBuf, std::io::Error>| pb.unwrap_or_default().to_string_lossy().to_string();
-    // First, inherit any env vars from the parent process
-    let term = {
-      if isatty(stdin_fileno()).unwrap_or_default() {
-        if let Ok(term) = std::env::var("TERM") {
-          term
-        } else {
-          "linux".to_string()
-        }
-      } else {
-        "xterm-256color".to_string()
-      }
-    };
-    let home_fallback;
-    let username_fallback;
-    let uid;
-    if let Some(user) = User::from_uid(nix::unistd::Uid::current()).ok().flatten() {
-      home_fallback = user.dir;
-      username_fallback = user.name;
-      uid = user.uid;
-    } else {
-      home_fallback = PathBuf::new();
-      username_fallback = "unknown".into();
-      uid = 0.into();
-    }
-    let home_fallback = pathbuf_to_string(Ok(home_fallback));
-    let hostname = gethostname()
-      .map(|hname| hname.to_string_lossy().to_string())
-      .unwrap_or_default();
-
-    let mut resolve = |var: &str, fallback: &str| -> String {
-      let val = std::env::var(var).unwrap_or_else(|_| fallback.to_string());
-
-      unsafe { std::env::set_var(var, &val) };
-      vars.push((var.to_string(), Var::env_var(&val)));
-      val
-    };
-
-    let resolved_home = resolve("HOME", &home_fallback);
-    let resolved_user = resolve("USER", &username_fallback);
-
-    let mut data_dir =
-      dirs::data_dir().unwrap_or_else(|| PathBuf::from(format!("{resolved_home}/.local/share")));
-    data_dir.push("shed");
-
-    let shed_db = data_dir.join("shed_hist.db");
-
-    resolve("TMPDIR", "/tmp");
-    resolve("TERM", &term);
-    resolve("LANG", "en_US.UTF-8");
-    resolve("LOGNAME", &resolved_user);
-    resolve("PWD", &pathbuf_to_string(std::env::current_dir()));
-    resolve("OLDPWD", &pathbuf_to_string(std::env::current_dir()));
-    resolve("SHELL", &pathbuf_to_string(std::env::current_exe()));
-    resolve("SHED_HIST", &format!("{resolved_home}/.shed_history"));
-    resolve("SHED_HISTDB", &shed_db.display().to_string());
-    resolve("SHED_RC", &format!("{resolved_home}/.shedrc"));
-
-    let mut set_var = |var: &str, val: &str| {
-      unsafe { std::env::set_var(var, val) };
-      vars.push((var.to_string(), Var::env_var(val)))
-    };
-
-    set_var("IFS", " \t\n");
-    set_var("UID", &uid.to_string());
-    set_var("PPID", &getppid().to_string());
-    set_var("HOST", &hostname.clone());
 
     vars
   }


### PR DESCRIPTION
shed now uses $XDG_CONFIG_HOME/shed to store its config files by default. `shedrc` lookup starts here, and falls back to `~/.shedrc` if its not found, maintaining backwards compatibility with existing `.shedrc` placements.

Also, fixed a subtle bug in the variable table's environment initialization that caused it to run per-thread instead of per-process.

Closes #24 