### PR TITLE
fix: terminal now queues events when waiting for cursor position query

### DIFF
--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -82,7 +82,9 @@ fn handle_signals_interactive(readline: &mut ShedLine) -> ShResult<bool> {
 fn get_poll_timeout(readline: &mut ShedLine) -> (PollTimeout, Option<String>) {
   let mut exec_if_timeout = None;
 
-  let timeout = if !readline.pending_keymap().is_empty() {
+  let timeout = if Shed::term(|t| t.reader_has_pending()) {
+    PollTimeout::ZERO
+  } else if !readline.pending_keymap().is_empty() {
     // wait for more keymap keys
     PollTimeout::from(1000u16)
   } else if let Some(timeout) = Shed::meta_mut(|m| m.take_poll_timeout()) {

--- a/src/readline/mod.rs
+++ b/src/readline/mod.rs
@@ -622,7 +622,6 @@ impl ShedLine {
   }
 
   fn handle_hist_search_key(&mut self, key: KeyEvent) -> ShResult<()> {
-    self.print_line(false)?;
     let finder = self.history_fzf().unwrap();
     match finder.handle_key(key)? {
       SelectorResponse::Accept(cmd) => {
@@ -681,7 +680,6 @@ impl ShedLine {
   }
 
   fn handle_completion_key(&mut self, key: &KeyEvent) -> ShResult<bool> {
-    self.print_line(false)?;
     let comp = self.completer.as_mut().unwrap();
     match comp.handle_key(key.clone())? {
       CompResponse::Accept(candidate) => {

--- a/src/state/terminal/mod.rs
+++ b/src/state/terminal/mod.rs
@@ -518,6 +518,10 @@ impl Terminal {
     }
   }
 
+  pub fn reader_has_pending(&self) -> bool {
+    self.reader.has_pending()
+  }
+
   pub fn poll(&mut self, timeout: PollTimeout) -> ShResult<i32> {
     let Some(tty) = self.tty() else { return Ok(0) };
     let poll_fd = PollFd::new(tty, PollFlags::POLLIN);
@@ -542,8 +546,9 @@ impl Terminal {
 
     self.reader.read(tty)?;
 
-    while let Some(event) = self.reader.read_event()? {
+    while let Some(event) = self.reader.read_event_from_bytes()? {
       let TermEvent::CursorPos(row, col) = event else {
+        self.reader.push_event(event);
         continue;
       };
       return Ok(Some((row, col)));

--- a/src/state/terminal/parse.rs
+++ b/src/state/terminal/parse.rs
@@ -539,6 +539,7 @@ pub(crate) struct PollReader {
   parser: vte::Parser,
   collector: EventParser,
   byte_buf: VecDeque<u8>,
+  pending_events: VecDeque<TermEvent>,
   pub verbatim_single: bool,
 }
 
@@ -548,6 +549,7 @@ impl Clone for PollReader {
       parser: vte::Parser::new(),
       collector: self.collector.clone(),
       byte_buf: self.byte_buf.clone(),
+      pending_events: self.pending_events.clone(),
       verbatim_single: self.verbatim_single,
     }
   }
@@ -560,6 +562,7 @@ impl Debug for PollReader {
       .field("collector", &self.collector)
       .field("byte_buf", &self.byte_buf)
       .field("verbatim_single", &self.verbatim_single)
+      .field("pending_events", &self.pending_events)
       .finish()
   }
 }
@@ -570,6 +573,7 @@ impl PollReader {
       parser: vte::Parser::new(),
       collector: EventParser::new(),
       byte_buf: VecDeque::new(),
+      pending_events: VecDeque::new(),
       verbatim_single: false,
     }
   }
@@ -617,7 +621,21 @@ impl PollReader {
     }
   }
 
-  pub(super) fn read_event(&mut self) -> Result<Option<TermEvent>, ShErr> {
+  pub(super) fn push_event(&mut self, event: TermEvent) {
+    self.pending_events.push_back(event);
+  }
+
+  pub(super) fn has_pending(&self) -> bool {
+    !self.pending_events.is_empty() || !self.byte_buf.is_empty()
+  }
+
+  pub(super) fn read_event(&mut self) -> ShResult<Option<TermEvent>> {
+    if let Some(ev) = self.pending_events.pop_front() {
+      return Ok(Some(ev));
+    }
+    self.read_event_from_bytes()
+  }
+  pub(super) fn read_event_from_bytes(&mut self) -> ShResult<Option<TermEvent>> {
     if self.verbatim_single {
       if let Some(key) = self.read_one_verbatim() {
         self.verbatim_single = false;


### PR DESCRIPTION
The Terminal struct currently discards TermEvents while it is waiting for the cursor position query response. The fix is to instead queue the events to be consumed later.

Closes #19 