### PR TITLE
feat: escape the preview of variable suggestion

### DIFF
--- a/src/readline/complete.rs
+++ b/src/readline/complete.rs
@@ -595,7 +595,7 @@ pub(crate) fn complete_vars(start: &str) -> Vec<Candidate> {
       .keys()
       .map(|s| {
         if let Some(val) = try_var!(s) {
-          Candidate::from(s).with_desc(val)
+          Candidate::from(s).with_desc(val.escape_debug().collect())
         } else {
           Candidate::from(s)
         }


### PR DESCRIPTION
Fixes #18

This PR will escape (non shell compatible) the variable previews in fzf.

Doing so allows users to more easily read the values of env-vars with non-printables as well as preventing those containing control codes to break the display.