### PR TITLE
fix: handle sigint gracefully (like older version)

### DIFF
--- a/src/signal.rs
+++ b/src/signal.rs
@@ -37,6 +37,7 @@ pub static GOT_SIGWINCH: AtomicBool = AtomicBool::new(false);
 pub static GOT_SIGUSR1: AtomicBool = AtomicBool::new(false);
 
 const MISC_SIGNALS: &[Signal] = &[
+  Signal::SIGINT,
   Signal::SIGILL,
   Signal::SIGTRAP,
   Signal::SIGABRT,


### PR DESCRIPTION
Add the missing SIGINT to MISC_SIGNAL so that setup signal consistent with the old version.