### PR TITLE
feat: improve the help pager

### DIFF
--- a/src/builtin/help/markup.rs
+++ b/src/builtin/help/markup.rs
@@ -4,7 +4,7 @@ use super::{expand::markers, match_loop, util::QuoteState};
 
 pub const TAG_SEQ: &str = "\x1b[1;33m"; // bold yellow - searchable tags
 pub const REF_SEQ: &str = "\x1b[4;36m"; // underline cyan - cross-references
-pub const SEARCH_RES_SEQ: &str = "\x1b[1;7;m"; // bold inverse - search result highlight
+pub const SEARCH_RES_SEQ: &str = "\x1b[1;7m"; // bold inverse - search result highlight
 pub const RESET_SEQ: &str = "\x1b[0m";
 pub const HEADER_SEQ: &str = "\x1b[1;35m"; // bold magenta - section headers
 pub const CODE_SEQ: &str = "\x1b[32m"; // green - inline code

--- a/src/builtin/help/markup.rs
+++ b/src/builtin/help/markup.rs
@@ -5,6 +5,7 @@ use super::{expand::markers, match_loop, util::QuoteState};
 pub const TAG_SEQ: &str = "\x1b[1;33m"; // bold yellow - searchable tags
 pub const REF_SEQ: &str = "\x1b[4;36m"; // underline cyan - cross-references
 pub const SEARCH_RES_SEQ: &str = "\x1b[1;7m"; // bold inverse - search result highlight
+pub const SEARCH_FOCUS_SEQ: &str = "\x1b[1;36;7m"; // bold inverse cyan - search result focus
 pub const RESET_SEQ: &str = "\x1b[0m";
 pub const HEADER_SEQ: &str = "\x1b[1;35m"; // bold magenta - section headers
 pub const CODE_SEQ: &str = "\x1b[32m"; // green - inline code

--- a/src/builtin/help/pager.rs
+++ b/src/builtin/help/pager.rs
@@ -33,7 +33,7 @@ struct SearchQuery {
   editor: SimpleEditor,
   dir: Direction,
   results: Vec<(usize, usize)>,
-  active_result_idx: usize,
+  active_result_idx1: usize,
   anchor: usize, // line we started on
   active: bool,
 }
@@ -43,7 +43,7 @@ impl SearchQuery {
     self.active = false;
     self.editor.buf.clear_buffer();
     self.results.clear();
-    self.active_result_idx = 0;
+    self.active_result_idx1 = 0;
   }
 
   pub fn is_empty(&self) -> bool {
@@ -193,7 +193,7 @@ impl HelpPager {
     let mut cur: usize = self.search.results.len();
     for (s, e) in self.search.results.iter().rev() {
       content.insert_str(*e, RESET_SEQ);
-      let seq = if cur - 1 == self.search.active_result_idx {
+      let seq = if cur == self.search.active_result_idx1 {
           SEARCH_FOCUS_SEQ
       } else {
         SEARCH_RES_SEQ
@@ -421,7 +421,6 @@ impl HelpPager {
     }
 
     let content = self.content();
-    let anchor = self.search.anchor;
 
     // I'd like to personally thank the borrow checker for forcing this thing into existence
     let lf_positions: Vec<_> = content
@@ -440,10 +439,14 @@ impl HelpPager {
 
     // Try to find a match past the anchor in the given direction
     let after_anchor = self.search.results.iter().filter(|(start, _)| {
-      let line_no = line_for(start);
-      match dir {
-        Direction::Forward => line_no > anchor,
-        Direction::Backward => line_no < anchor,
+      if self.search.active_result_idx1 > 0 {
+          let current_range = self.search.results[self.search.active_result_idx1 - 1];
+          match dir {
+            Direction::Forward => *start > current_range.1,
+            Direction::Backward => *start < current_range.0,
+          }
+      } else {
+          true
       }
     });
 
@@ -458,24 +461,32 @@ impl HelpPager {
       Direction::Backward => self.search.results.iter().max_by_key(|(start, _)| *start),
     });
 
+    let height = Shed::term(|t| t.t_rows()).saturating_sub(1); // Get current terminal height
     if let Some((start, _)) = found {
       let line_no = line_for(start);
-      self.scroll_offset = line_no.saturating_sub(1);
+      
+      // Check if the target line is already in the viewport
+      let is_visible = line_no >= self.scroll_offset && line_no < (self.scroll_offset + height);
+      
+      if !is_visible {
+        // Only jump if not visible
+        self.scroll_offset = line_no.saturating_sub(2);
+      }
       self.search.anchor = line_no;
     }
+
     // update the focus index
     match dir {
         Direction::Forward => {
-            self.search.active_result_idx += 1;
-            if self.search.active_result_idx >= self.search.results.len() {
-                self.search.active_result_idx = 0;
+            self.search.active_result_idx1 += 1;
+            if self.search.active_result_idx1 > self.search.results.len() {
+                self.search.active_result_idx1 = 1;
             }
         },
         Direction::Backward => {
-            if self.search.active_result_idx == 0 {
-                self.search.active_result_idx = self.search.results.len() - 1;
-            } else {
-                self.search.active_result_idx -= 1;
+            self.search.active_result_idx1 -= 1;
+            if self.search.active_result_idx1 == 0 {
+                self.search.active_result_idx1 = self.search.results.len();
             }
         },
     }

--- a/src/builtin/help/pager.rs
+++ b/src/builtin/help/pager.rs
@@ -6,7 +6,7 @@ use regex::Regex;
 use super::{
   Direction, ShResult, Shed, StyledHelp, key,
   keys::{KeyCode, KeyEvent},
-  markup::{MarkedSpan, REF_SEQ, RESET_SEQ, SEARCH_RES_SEQ, TAG_SEQ,SEARCH_FOCUS_SEQ,},
+  markup::{MarkedSpan, REF_SEQ, RESET_SEQ, SEARCH_FOCUS_SEQ, SEARCH_RES_SEQ, TAG_SEQ},
   procio::stdout_fileno,
   readline::SimpleEditor,
   state::terminal::calc_str_width,
@@ -194,7 +194,7 @@ impl HelpPager {
     for (s, e) in self.search.results.iter().rev() {
       content.insert_str(*e, RESET_SEQ);
       let seq = if cur == self.search.active_result_idx1 {
-          SEARCH_FOCUS_SEQ
+        SEARCH_FOCUS_SEQ
       } else {
         SEARCH_RES_SEQ
       };
@@ -370,7 +370,9 @@ impl HelpPager {
       key!('d') | key!(PageDown) => PagerCmd::Scroll(self.jump_dist as isize),
       key!('u') | key!(PageUp) => PagerCmd::Scroll(-(self.jump_dist as isize)),
 
-      key!(ScrollDown) | key!(Down) | key!('j') | key!(Enter) if !self.search.active => PagerCmd::Scroll(1),
+      key!(ScrollDown) | key!(Down) | key!('j') | key!(Enter) if !self.search.active => {
+        PagerCmd::Scroll(1)
+      }
       key!(ScrollUp) | key!(Up) | key!('k') => PagerCmd::Scroll(-1),
       key!(Back) | key!(Left) | key!('h') => return Ok(PagerEvent::Back),
       key!(Forward) | key!(Right) | key!('l') => return Ok(PagerEvent::Forward),
@@ -440,13 +442,13 @@ impl HelpPager {
     // Try to find a match past the anchor in the given direction
     let after_anchor = self.search.results.iter().filter(|(start, _)| {
       if self.search.active_result_idx1 > 0 {
-          let current_range = self.search.results[self.search.active_result_idx1 - 1];
-          match dir {
-            Direction::Forward => *start > current_range.1,
-            Direction::Backward => *start < current_range.0,
-          }
+        let current_range = self.search.results[self.search.active_result_idx1 - 1];
+        match dir {
+          Direction::Forward => *start > current_range.1,
+          Direction::Backward => *start < current_range.0,
+        }
       } else {
-          true
+        true
       }
     });
 
@@ -464,10 +466,10 @@ impl HelpPager {
     let height = Shed::term(|t| t.t_rows()).saturating_sub(1); // Get current terminal height
     if let Some((start, _)) = found {
       let line_no = line_for(start);
-      
+
       // Check if the target line is already in the viewport
       let is_visible = line_no >= self.scroll_offset && line_no < (self.scroll_offset + height);
-      
+
       if !is_visible {
         // Only jump if not visible
         self.scroll_offset = line_no.saturating_sub(2);
@@ -477,18 +479,18 @@ impl HelpPager {
 
     // update the focus index
     match dir {
-        Direction::Forward => {
-            self.search.active_result_idx1 += 1;
-            if self.search.active_result_idx1 > self.search.results.len() {
-                self.search.active_result_idx1 = 1;
-            }
-        },
-        Direction::Backward => {
-            self.search.active_result_idx1 -= 1;
-            if self.search.active_result_idx1 == 0 {
-                self.search.active_result_idx1 = self.search.results.len();
-            }
-        },
+      Direction::Forward => {
+        self.search.active_result_idx1 += 1;
+        if self.search.active_result_idx1 > self.search.results.len() {
+          self.search.active_result_idx1 = 1;
+        }
+      }
+      Direction::Backward => {
+        self.search.active_result_idx1 -= 1;
+        if self.search.active_result_idx1 == 0 {
+          self.search.active_result_idx1 = self.search.results.len();
+        }
+      }
     }
   }
 

--- a/src/builtin/help/pager.rs
+++ b/src/builtin/help/pager.rs
@@ -361,7 +361,7 @@ impl HelpPager {
       key!('d') | key!(PageDown) => PagerCmd::Scroll(self.jump_dist as isize),
       key!('u') | key!(PageUp) => PagerCmd::Scroll(-(self.jump_dist as isize)),
 
-      key!(ScrollDown) | key!(Down) | key!('j') => PagerCmd::Scroll(1),
+      key!(ScrollDown) | key!(Down) | key!('j') | key!(Enter) if !self.search.active => PagerCmd::Scroll(1),
       key!(ScrollUp) | key!(Up) | key!('k') => PagerCmd::Scroll(-1),
       key!(Back) | key!(Left) | key!('h') => return Ok(PagerEvent::Back),
       key!(Forward) | key!(Right) | key!('l') => return Ok(PagerEvent::Forward),

--- a/src/builtin/help/pager.rs
+++ b/src/builtin/help/pager.rs
@@ -6,7 +6,7 @@ use regex::Regex;
 use super::{
   Direction, ShResult, Shed, StyledHelp, key,
   keys::{KeyCode, KeyEvent},
-  markup::{MarkedSpan, REF_SEQ, RESET_SEQ, SEARCH_RES_SEQ, TAG_SEQ},
+  markup::{MarkedSpan, REF_SEQ, RESET_SEQ, SEARCH_RES_SEQ, TAG_SEQ,SEARCH_FOCUS_SEQ,},
   procio::stdout_fileno,
   readline::SimpleEditor,
   state::terminal::calc_str_width,
@@ -33,6 +33,7 @@ struct SearchQuery {
   editor: SimpleEditor,
   dir: Direction,
   results: Vec<(usize, usize)>,
+  active_result_idx: usize,
   anchor: usize, // line we started on
   active: bool,
 }
@@ -42,6 +43,7 @@ impl SearchQuery {
     self.active = false;
     self.editor.buf.clear_buffer();
     self.results.clear();
+    self.active_result_idx = 0;
   }
 
   pub fn is_empty(&self) -> bool {
@@ -188,9 +190,16 @@ impl HelpPager {
       content.replace_range(prefix, HOVER_SEQ);
     }
 
+    let mut cur: usize = self.search.results.len();
     for (s, e) in self.search.results.iter().rev() {
       content.insert_str(*e, RESET_SEQ);
-      content.insert_str(*s, SEARCH_RES_SEQ);
+      let seq = if cur - 1 == self.search.active_result_idx {
+          SEARCH_FOCUS_SEQ
+      } else {
+        SEARCH_RES_SEQ
+      };
+      content.insert_str(*s, seq);
+      cur -= 1;
     }
 
     let content_lines: Vec<_> = content
@@ -453,6 +462,22 @@ impl HelpPager {
       let line_no = line_for(start);
       self.scroll_offset = line_no.saturating_sub(1);
       self.search.anchor = line_no;
+    }
+    // update the focus index
+    match dir {
+        Direction::Forward => {
+            self.search.active_result_idx += 1;
+            if self.search.active_result_idx >= self.search.results.len() {
+                self.search.active_result_idx = 0;
+            }
+        },
+        Direction::Backward => {
+            if self.search.active_result_idx == 0 {
+                self.search.active_result_idx = self.search.results.len() - 1;
+            } else {
+                self.search.active_result_idx -= 1;
+            }
+        },
     }
   }
 


### PR DESCRIPTION
- Add enter - scroll down
- Fix wrong ANSI control code in search result
- Implement focus search result highlighting and better jump to match (now the currently active result will be highlighted!)

There is still a subtle bug I want to fix but uh... I kind of get shutdown atp. Can you do it?

Apparently I think the way the search function fetch help may include beginning tags which are not rendered, making it a bit weird since you may focus on something you don't even see. It also contains control codes, so /[ wouldn't work so well. Maybe make them plaintext and strip header tags first?