### PR TITLE
fix: validate SHED_RC exists before returning it in rc_file_path()

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,12 @@ shopt core.max_hist=5000                      # history size
 shopt highlight.valid_command="bold green"    # customize highlight colors
 ```
 
-The rc file is loaded from `~/.shedrc` on startup.
+Shed searches for an rc file in these paths, in decreasing order of priority:
+
+1. $SHED_RC
+2. $XDG_CONFIG_HOME/shedrc
+3. $HOME/.config/shed/shedrc
+4. $HOME/.shedr
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Shed searches for an rc file in these paths, in decreasing order of priority:
 1. $SHED_RC
 2. $XDG_CONFIG_HOME/shedrc
 3. $HOME/.config/shed/shedrc
-4. $HOME/.shedr
+4. $HOME/.shedrc
 
 ---
 

--- a/src/state/vars.rs
+++ b/src/state/vars.rs
@@ -653,10 +653,6 @@ impl VarTab {
       data_dir.push("shed");
 
       let shed_db = data_dir.join("shed_hist.db");
-      let shed_rc = std::env::var("XDG_CONFIG_HOME").ok().map_or_else(
-        || PathBuf::from(format!("{resolved_home}/.config/shed/shedrc")),
-        |c| PathBuf::from(c).join("shed").join("shedrc"),
-      );
 
       resolve("TMPDIR", "/tmp");
       resolve("TERM", &term);
@@ -664,7 +660,6 @@ impl VarTab {
       resolve("LOGNAME", &resolved_user);
       resolve("SHELL", &pathbuf_to_string(std::env::current_exe()));
       resolve("SHED_HISTDB", &shed_db.display().to_string());
-      resolve("SHED_RC", &shed_rc.display().to_string());
 
       let set_var = |var: &str, val: &str| {
         unsafe { std::env::set_var(var, val) };


### PR DESCRIPTION
The SHED_RC env variable was being returned in rc_file_path, even if it was pointing to a non-existing or otherwise inaccessible file. This was causing the first run setup to run and create a default rc file even if ~/.shedrc exists.

Changed the logic to return it only after checking that the file exists, or that neither the XDG_CONFIG_HOME or HOME files exist.

An alternative solution might be to stop the program from setting SHED_RC to `~/.config/shed/shedrc` at launch, even if no variable is passed from the environment but I could not for the life of me figure out what caused that.