### PR TITLE
Fix `command cd` not calling the `cd` builtin

### DIFF
--- a/src/builtin/mod.rs
+++ b/src/builtin/mod.rs
@@ -831,18 +831,24 @@ impl CommandBuiltin {
       return with_status(0);
     }
 
-    // this one has to offload to the dispatcher
-    dispatcher.exec_cmd(node)
+    // Per POSIX, `command` suppresses alias/function lookup but must still
+    // execute shell builtins (and external commands). Route through the same
+    // dispatcher logic as `dispatch_cmd`, just with function lookup disabled.
+    dispatcher.route_command(node, false)
   }
 }
 
 #[cfg(test)]
 pub mod tests {
+  use std::env;
+
+  use tempfile::TempDir;
+
   use crate::{
     Shed, assert_status_eq,
     eval::execute::exec_nonint,
     state::{self, vars::VarFlags},
-    tests::testutil::{TestGuard, has_cmd, test_input},
+    tests::testutil::{TestGuard, canon, has_cmd, test_input},
   };
 
   // You can never be too sure!!!!!!
@@ -1093,6 +1099,45 @@ pub mod tests {
     test_input("F=echo; command -v $F").unwrap();
     let out = g.read_output();
     assert!(out.contains("echo"), "got: {out:?}");
+    assert_eq!(state::Shed::get_status(), 0);
+  }
+
+  // POSIX: `command` suppresses alias/function lookup but must still
+  // execute shell builtins. `cd` has no external counterpart, so this
+  // verifies the builtin (not execve) path is taken. See also bash/dash.
+  #[test]
+  fn command_invokes_cd_builtin() {
+    let _g = TestGuard::new();
+    let old_dir = env::current_dir().unwrap();
+    let temp_dir = TempDir::new().unwrap();
+
+    test_input(format!("command cd {}", temp_dir.path().display())).unwrap();
+
+    let new_dir = env::current_dir().unwrap();
+    assert_ne!(old_dir, new_dir, "cwd unchanged; `command cd` did not run the builtin");
+    assert_eq!(
+      new_dir.display().to_string(),
+      canon(temp_dir.path()).display().to_string()
+    );
+    assert_eq!(state::Shed::get_status(), 0);
+  }
+
+  // A backslash-quoted `\command` still routes through the `command`
+  // builtin after expansion, so it must behave the same as `command`.
+  #[test]
+  fn backslash_command_invokes_cd_builtin() {
+    let _g = TestGuard::new();
+    let old_dir = env::current_dir().unwrap();
+    let temp_dir = TempDir::new().unwrap();
+
+    test_input(format!("\\command cd {}", temp_dir.path().display())).unwrap();
+
+    let new_dir = env::current_dir().unwrap();
+    assert_ne!(old_dir, new_dir, "cwd unchanged; `\\command cd` did not run the builtin");
+    assert_eq!(
+      new_dir.display().to_string(),
+      canon(temp_dir.path()).display().to_string()
+    );
     assert_eq!(state::Shed::get_status(), 0);
   }
 

--- a/src/builtin/mod.rs
+++ b/src/builtin/mod.rs
@@ -93,7 +93,6 @@ macro_rules! register_builtins {
 // these have to be in alphabetical order, because of the way lookup_builtin() works
 // if the list is unsorted, that is a compile error thanks to the const evaluation above
 // if you're using vim, you can visual select the block and filter it through ''<,'>:!LC_ALL=C sort'
-// you can also yank this macro and execute it with @" -> /^register_builtins!$viB:!LC_ALL=C sort:wviBga=:w
 // if you're not using vim, idk. you know the alphabet right?
 register_builtins! {
   "."        => source::Source,

--- a/src/eval/execute.rs
+++ b/src/eval/execute.rs
@@ -401,6 +401,21 @@ impl Dispatcher {
     let (line, _) = node.get_span().clone().line_and_col();
     Shed::vars_mut(|v| v.set_var("LINENO", VarKind::Int((line + 1) as i32), VarFlags::empty()))?;
 
+    let result = self.route_command(node, true);
+    commit_underscore();
+    result
+  }
+
+  /// Route a simple command to its executor: function, builtin, arithmetic,
+  /// autocd, or external `exec_cmd`.
+  ///
+  /// `allow_func` gates function lookup. The `command` builtin passes `false`
+  /// so that, per POSIX, it suppresses function lookup while still running
+  /// shell builtins and external commands.
+  ///
+  /// `expand_to_words` is idempotent on already-expanded tokens, so this is
+  /// safe to call on the pre-expanded node built by `command`/`builtin`.
+  pub(crate) fn route_command(&mut self, node: &Node, allow_func: bool) -> ShResult<()> {
     let Some(cmd) = node.get_command() else {
       return self.exec_cmd(node); // Argv is empty, probably an assignment
     };
@@ -422,7 +437,7 @@ impl Dispatcher {
 
     let cmd_tk = node.get_command();
 
-    let result = if is_func(&cmd_word) {
+    if allow_func && is_func(&cmd_word) {
       self.exec_func(node)
     } else if cmd.flags.contains(TkFlags::BUILTIN) || BUILTIN_NAMES.contains(&cmd_word.as_str()) {
       self.exec_builtin(node, &cmd_word)
@@ -433,10 +448,7 @@ impl Dispatcher {
       exec_input(varstr!("cd {dir}"), Some(self.source_name.clone()))
     } else {
       self.exec_cmd(node)
-    };
-
-    commit_underscore();
-    result
+    }
   }
   pub fn exec_defer(node: &Node) -> ShResult<()> {
     let NdRule::DeferNode { body } = &node.class else {


### PR DESCRIPTION
I stumbled upon these when trying to integrate zoxide with shed. This is a first from a series of fixes, however these were LLM assisted. Let me know, if I should continue publishing. I review what I can, but parsing/shells are a bit out of my depth.