### PR TITLE
fix(expand): literal `(` in ${var#pat}/${var%pat}/${var/pat/rep} patterns

### DIFF
--- a/src/expand/escape.rs
+++ b/src/expand/escape.rs
@@ -28,6 +28,13 @@ impl ExpandFlags {
   const HEREDOC: Self = Self::VAR.union(Self::CMDSUB);
 
   const PROMPT: Self = Self::VAR.union(Self::CMDSUB);
+
+  /// Word expansion minus bare `(...)` subshell recognition. Used for the
+  /// pattern and replacement operands of `${var#pat}`, `${var%pat}`,
+  /// `${var/pat/rep}`, ... where a literal `(` must reach the glob matcher
+  /// instead of being consumed as a subshell. `$(...)` and `$var` still
+  /// expand (CMDSUB/VAR stay on).
+  const PATTERN: Self = Self::WORD.difference(Self::SUBSHELL);
 }
 
 /// Strip ESCAPE markers from a string, leaving the characters they protect intact.
@@ -133,8 +140,25 @@ fn unescape_with(raw: &str, flags: ExpandFlags) -> String {
     (String::new(), false, false)
   };
 
+  // Depth inside a `${...}` parameter expansion. A bare `(` inside the body is
+  // part of a pattern/operand (e.g. `${v%(x)}`, `${v/x/(y)}`), not a
+  // subshell — keep it literal so it reaches the glob matcher. `$(...)`
+  // cmdsubs still work (handled by the CMDSUB arm, which consumes its own
+  // parens), and nested `${...}` increments this counter.
+  let mut param_depth: u32 = 0;
+
   while let Some(ch) = chars.next() {
     match ch {
+      // An existing ESCAPE marker (from a prior unescape pass, e.g. the
+      // marker-encoded operand of a parameter expansion) means the next
+      // char is literal — preserve both without re-processing, so e.g.
+      // `${v%\$(echo x)}` keeps `$(...)` literal instead of running it.
+      markers::ESCAPE => {
+        result.push(markers::ESCAPE);
+        if let Some(next_ch) = chars.next() {
+          result.push(next_ch);
+        }
+      }
       '~' if flags.contains(ExpandFlags::TILDE) && (last_was_word_break || first_char) => {
         result.push(markers::TILDE_SUB);
       }
@@ -166,9 +190,24 @@ fn unescape_with(raw: &str, flags: ExpandFlags) -> String {
       }
       '$' if flags.intersects(ExpandFlags::VAR.union(ExpandFlags::CMDSUB)) => {
         read_varsub(&mut chars, &mut result);
+        // `${` opens a parameter expansion; track depth so bare `(` inside the
+        // body stays literal.
+        if chars.peek() == Some(&'{') {
+          chars.next();
+          result.push('{');
+          param_depth = param_depth.saturating_add(1);
+        }
       }
-      // Bare `(...)` as a substitution — only in word context.
-      '(' if flags.contains(ExpandFlags::SUBSHELL) => read_subsh(&mut chars, &mut result),
+      // `}` closes the innermost `${...}` body.
+      '}' if param_depth > 0 => {
+        result.push('}');
+        param_depth = param_depth.saturating_sub(1);
+      }
+      // Bare `(...)` as a substitution — only in word context, and only when
+      // not inside a `${...}` (where a bare `(` is a literal pattern char).
+      '(' if flags.contains(ExpandFlags::SUBSHELL) && param_depth == 0 => {
+        read_subsh(&mut chars, &mut result)
+      }
       _ => result.push(ch),
     }
     if flags.contains(ExpandFlags::TILDE) {
@@ -184,6 +223,14 @@ fn unescape_with(raw: &str, flags: ExpandFlags) -> String {
 /// process subs, escapes. Used by the main expansion pipeline.
 pub fn unescape_str(raw: &str) -> String {
   unescape_with(raw, ExpandFlags::WORD)
+}
+
+/// Like `unescape_str` but for the pattern/replacement operand of a parameter
+/// expansion (`${var#pat}`, `${var%pat}`, `${var/pat/rep}`, ...): a bare `(` is
+/// a literal character, not a subshell. `$(...)`, `$var`, quotes, etc. still
+/// expand as in word context.
+pub(crate) fn unescape_pattern(raw: &str) -> String {
+  unescape_with(raw, ExpandFlags::PATTERN)
 }
 
 /// Prompt-context unescape: $var, ${var}, $(cmd), backticks. No quote handling,

--- a/src/expand/mod.rs
+++ b/src/expand/mod.rs
@@ -163,12 +163,23 @@ impl Expander {
     Self::from_raw(tk_raw, raw.flags)
   }
   pub fn from_raw(raw: &str, flags: TkFlags) -> Self {
-    Self::from_raw_inner(raw, flags, true)
+    Self::from_raw_inner(raw, flags, true, false)
   }
+  #[allow(dead_code)]
   pub fn from_raw_no_brace(raw: &str, flags: TkFlags) -> Self {
-    Self::from_raw_inner(raw, flags, false)
+    Self::from_raw_inner(raw, flags, false, false)
   }
-  fn from_raw_inner(raw: &str, flags: TkFlags, expand_braces: bool) -> Self {
+  /// Like `from_raw` but the operand is a parameter-expansion pattern or
+  /// replacement (`${var#pat}`, `${var%pat}`, `${var/pat/rep}`): a bare `(` is
+  /// literal, not a subshell.
+  pub fn from_raw_pattern(raw: &str, flags: TkFlags) -> Self {
+    Self::from_raw_inner(raw, flags, true, true)
+  }
+  /// Brace-free variant of `from_raw_pattern`.
+  pub fn from_raw_no_brace_pattern(raw: &str, flags: TkFlags) -> Self {
+    Self::from_raw_inner(raw, flags, false, true)
+  }
+  fn from_raw_inner(raw: &str, flags: TkFlags, expand_braces: bool, for_pattern: bool) -> Self {
     let raw = if expand_braces && raw.contains('{') {
       brace::expand_braces_full(raw).join(" ")
     } else {
@@ -176,6 +187,8 @@ impl Expander {
     };
     let unescaped = if flags.contains(TkFlags::IS_HEREDOC) {
       unescape_heredoc(&raw)
+    } else if for_pattern {
+      escape::unescape_pattern(&raw)
     } else {
       unescape_str(&raw)
     };

--- a/src/expand/param.rs
+++ b/src/expand/param.rs
@@ -438,7 +438,7 @@ pub fn perform_param_expansion(raw: &str, allow_side_effects: bool) -> ShResult<
       }
       ParamExp::RemShortestPrefix(prefix) => {
         let value = Shed::vars(get);
-        let expanded = Expander::from_raw_no_brace(&prefix, TkFlags::empty())
+        let expanded = Expander::from_raw_no_brace_pattern(&prefix, TkFlags::empty())
           .no_glob()
           .expand_for_glob()?;
         let pattern = compile_glob(&expanded).unwrap();
@@ -454,7 +454,7 @@ pub fn perform_param_expansion(raw: &str, allow_side_effects: bool) -> ShResult<
       }
       ParamExp::RemLongestPrefix(prefix) => {
         let value = Shed::vars(get);
-        let expanded = Expander::from_raw_no_brace(&prefix, TkFlags::empty())
+        let expanded = Expander::from_raw_no_brace_pattern(&prefix, TkFlags::empty())
           .no_glob()
           .expand_for_glob()?;
         let pattern = compile_glob(&expanded).unwrap();
@@ -473,7 +473,7 @@ pub fn perform_param_expansion(raw: &str, allow_side_effects: bool) -> ShResult<
       }
       ParamExp::RemShortestSuffix(suffix) => {
         let value = Shed::vars(get);
-        let expanded = Expander::from_raw_no_brace(&suffix, TkFlags::empty())
+        let expanded = Expander::from_raw_no_brace_pattern(&suffix, TkFlags::empty())
           .no_glob()
           .expand_for_glob()?;
         let pattern = compile_glob(&expanded).unwrap();
@@ -492,7 +492,7 @@ pub fn perform_param_expansion(raw: &str, allow_side_effects: bool) -> ShResult<
       }
       ParamExp::RemLongestSuffix(suffix) => {
         let value = Shed::vars(get);
-        let expanded_suffix = Expander::from_raw_no_brace(&suffix, TkFlags::empty())
+        let expanded_suffix = Expander::from_raw_no_brace_pattern(&suffix, TkFlags::empty())
           .no_glob()
           .expand_for_glob()?;
         let pattern = compile_glob(&expanded_suffix).unwrap();
@@ -508,10 +508,10 @@ pub fn perform_param_expansion(raw: &str, allow_side_effects: bool) -> ShResult<
       }
       ParamExp::ReplaceFirstMatch(search, replace) => {
         let value = Shed::vars(get);
-        let expanded_search = Expander::from_raw(&search, TkFlags::empty())
+        let expanded_search = Expander::from_raw_pattern(&search, TkFlags::empty())
           .no_glob()
           .expand_for_glob()?;
-        let expanded_replace = Expander::from_raw(&replace, TkFlags::empty())
+        let expanded_replace = Expander::from_raw_pattern(&replace, TkFlags::empty())
           .no_glob()
           .expand_no_split()?;
         let regex = glob_to_regex(&expanded_search, false); // unanchored pattern
@@ -529,10 +529,10 @@ pub fn perform_param_expansion(raw: &str, allow_side_effects: bool) -> ShResult<
       }
       ParamExp::ReplaceAllMatches(search, replace) => {
         let value = Shed::vars(get);
-        let expanded_search = Expander::from_raw(&search, TkFlags::empty())
+        let expanded_search = Expander::from_raw_pattern(&search, TkFlags::empty())
           .no_glob()
           .expand_for_glob()?;
-        let expanded_replace = Expander::from_raw(&replace, TkFlags::empty())
+        let expanded_replace = Expander::from_raw_pattern(&replace, TkFlags::empty())
           .no_glob()
           .expand_no_split()?;
         let regex = glob_to_regex(&expanded_search, false);
@@ -552,10 +552,10 @@ pub fn perform_param_expansion(raw: &str, allow_side_effects: bool) -> ShResult<
       }
       ParamExp::ReplacePrefix(search, replace) => {
         let value = Shed::vars(get);
-        let expanded_search = Expander::from_raw(&search, TkFlags::empty())
+        let expanded_search = Expander::from_raw_pattern(&search, TkFlags::empty())
           .no_glob()
           .expand_for_glob()?;
-        let expanded_replace = Expander::from_raw(&replace, TkFlags::empty())
+        let expanded_replace = Expander::from_raw_pattern(&replace, TkFlags::empty())
           .no_glob()
           .expand_no_split()?;
         let pattern = compile_glob(&expanded_search).unwrap();
@@ -571,10 +571,10 @@ pub fn perform_param_expansion(raw: &str, allow_side_effects: bool) -> ShResult<
       }
       ParamExp::ReplaceSuffix(search, replace) => {
         let value = Shed::vars(get);
-        let expanded_search = Expander::from_raw(&search, TkFlags::empty())
+        let expanded_search = Expander::from_raw_pattern(&search, TkFlags::empty())
           .no_glob()
           .expand_for_glob()?;
-        let expanded_replace = Expander::from_raw(&replace, TkFlags::empty())
+        let expanded_replace = Expander::from_raw_pattern(&replace, TkFlags::empty())
           .no_glob()
           .expand_no_split()?;
         let pattern = compile_glob(&expanded_search).unwrap();
@@ -1088,6 +1088,37 @@ mod tests {
 
     let out = guard.read_output();
     assert_eq!(out, "hello world\n");
+  }
+
+  // A bare `(` in a strip pattern is a literal pattern char, not a subshell.
+  // Regression: the token-level unescape consumed `(` as a subshell marker,
+  // so `${v%(x)}` never matched (and in some cases ran the parenthesized
+  // text as a command). Must work both unquoted and inside double quotes.
+  #[test]
+  fn param_exp_suffix_removal_bare_parens() {
+    let guard = TestGuard::new();
+    Shed::vars_mut(|v| v.set_var("v", VarKind::Str("abc(x)".into()), VarFlags::empty())).unwrap();
+
+    test_input("echo ${v%(x)}").unwrap();
+    assert_eq!(guard.read_output(), "abc\n");
+  }
+
+  #[test]
+  fn param_exp_suffix_removal_bare_parens_double_quoted() {
+    let guard = TestGuard::new();
+    Shed::vars_mut(|v| v.set_var("v", VarKind::Str("abc(x)".into()), VarFlags::empty())).unwrap();
+
+    test_input("echo \"${v%(x)}\"").unwrap();
+    assert_eq!(guard.read_output(), "abc\n");
+  }
+
+  #[test]
+  fn param_exp_prefix_removal_bare_parens() {
+    let guard = TestGuard::new();
+    Shed::vars_mut(|v| v.set_var("v", VarKind::Str("(x)abc".into()), VarFlags::empty())).unwrap();
+
+    test_input("echo ${v#(x)}").unwrap();
+    assert_eq!(guard.read_output(), "abc\n");
   }
 
   #[test]
@@ -1607,5 +1638,75 @@ mod tests {
     assert_eq!(test_param_expansion("x:0:1").unwrap().as_str(), "田");
     assert_eq!(test_param_expansion("x:1:1").unwrap().as_str(), "中");
     assert_eq!(test_param_expansion("x:2:2").unwrap().as_str(), "さん");
+  }
+
+  // ─── pattern operands must not treat `(` as a subshell ────────────
+  // A bare `(` in a strip/replace pattern was being consumed by the
+  // subshell recognizer (ExpandFlags::SUBSHELL) before reaching the glob
+  // matcher, so `${v%(x)}` never matched. Only `$(...)` should run.
+  #[test]
+  fn rem_shortest_suffix_strips_literal_parens() {
+    let _g = TestGuard::new();
+    set("x", "abc(x)");
+    let result = test_param_expansion("x%(x)").unwrap();
+    assert_eq!(result.as_str(), "abc");
+  }
+
+  #[test]
+  fn rem_shortest_prefix_strips_literal_parens() {
+    let _g = TestGuard::new();
+    set("x", "(x)abc");
+    let result = test_param_expansion("x#(x)").unwrap();
+    assert_eq!(result.as_str(), "abc");
+  }
+
+  #[test]
+  fn rem_longest_suffix_strips_literal_parens_glob() {
+    let _g = TestGuard::new();
+    set("x", "abc(x)(x)");
+    let result = test_param_expansion("x%%(x)").unwrap();
+    assert_eq!(result.as_str(), "abc(x)");
+  }
+
+  #[test]
+  fn rem_longest_prefix_strips_literal_parens_glob() {
+    let _g = TestGuard::new();
+    set("x", "(x)(x)abc");
+    let result = test_param_expansion("x##(x)").unwrap();
+    assert_eq!(result.as_str(), "(x)abc");
+  }
+
+  #[test]
+  fn rem_suffix_glob_with_open_paren_matches() {
+    let _g = TestGuard::new();
+    set("x", "abc(x)");
+    let result = test_param_expansion("x%(*)").unwrap();
+    assert_eq!(result.as_str(), "abc");
+  }
+
+  #[test]
+  fn replace_first_match_with_parens_in_search() {
+    let _g = TestGuard::new();
+    set("x", "abc(x)");
+    let result = test_param_expansion("x/abc(x)/X").unwrap();
+    assert_eq!(result.as_str(), "X");
+  }
+
+  #[test]
+  fn replace_suffix_with_parens_in_search() {
+    let _g = TestGuard::new();
+    set("x", "abc(x)");
+    // Anchored suffix replace uses `${v/%pat/rep}`.
+    let result = test_param_expansion("x/%abc(x)/X").unwrap();
+    assert_eq!(result.as_str(), "X");
+  }
+
+  #[test]
+  fn replace_first_match_with_parens_in_replacement() {
+    let _g = TestGuard::new();
+    set("x", "abc");
+    // A bare `(` in the replacement is literal, not a subshell.
+    let result = test_param_expansion("x/abc/(x)").unwrap();
+    assert_eq!(result.as_str(), "(x)");
   }
 }


### PR DESCRIPTION
A bare `(` in a parameter-expansion pattern operand was consumed by the subshell recognizer before reaching the glob matcher, so e.g. `${v%(x)}` never matched (and the parenthesized text could be executed as a command). Only $(...) should run; a bare ( is a literal pattern char (matches bash).

Two layers:

1. Token-level unescape (unescape_with): track ${...} depth and don't convert a bare ( to a SUBSH marker inside the body. $(...) cmdsubs still work (separate arm). Also honor an existing ESCAPE marker so an escaped char (e.g. \$) is not re-processed on a second unescape pass.

2. Pattern operand (Expander::from_raw_pattern/from_raw_no_brace_pattern): unescape with SUBSHELL disabled (ExpandFlags::PATTERN = WORD \ SUBSHELL) so the literal ( isn't re-mangled when the pattern is expanded.

Adds 11 regression tests (8 direct via perform_param_expansion, 3 shell-path via test_input covering unquoted/double-quoted cases).

Another problem I found when trying to make zoxide work (before I discovered zd), LLM analyzed and fixed, feel free to reject.