### PR TITLE
fix(assign): assignment-only command exit status is last cmdsub status

### DIFF
--- a/src/eval/execute.rs
+++ b/src/eval/execute.rs
@@ -17,6 +17,7 @@ use std::{
   rc::Rc,
 };
 
+use crate::expand::subshell::{last_cmdsub_status, reset_last_cmdsub_status};
 use crate::state::util::with_vars;
 use crate::util::posix_extension::execvpe;
 
@@ -1504,12 +1505,17 @@ impl Dispatcher {
     if let AssignBehavior::Set = assign_behavior {
       // argv is empty: a command with no command word. Perform any assignments
       // in the current shell, then apply any redirections.
-      if !assignments.is_empty()
-        && let Err(e) = Self::set_assignments(assignments, assign_behavior)
-      {
-        Shed::set_status(1);
-        e.print_error();
-        return Ok(());
+      if !assignments.is_empty() {
+        // Reset the cmdsub-status cell so it reflects only the command
+        // substitutions performed by this assignment command, not any from a
+        // previous command. `set_assignments` reads it to derive `$?` per
+        // POSIX (last cmdsub status, or 0).
+        reset_last_cmdsub_status();
+        if let Err(e) = Self::set_assignments(assignments, assign_behavior) {
+          Shed::set_status(1);
+          e.print_error();
+          return Ok(());
+        }
       }
       match RedirSet::from(&cmd.redirs).try_apply(false) {
         RedirResult::Applied(_) | RedirResult::NoRedirs => {
@@ -1716,6 +1722,13 @@ impl Dispatcher {
       };
       let old_status = Shed::get_status();
       let var_name = var.span.as_str();
+      // For an assignment-only command (Set), the exit status is the last
+      // command substitution's status (or 0). Reset `$?` before expanding so
+      // a leftover non-zero status from a prior command can't masquerade as an
+      // expansion failure; the cmdsub cell tracks whether one actually ran.
+      if matches!(behavior, AssignBehavior::Set) {
+        Shed::set_status(0);
+      }
       let is_integer = !is_arr
         && Shed::vars(|v| v.get_var_flags(var_name)).is_some_and(|f| f.contains(VarFlags::INTEGER));
       let val = if is_arr {
@@ -1787,7 +1800,13 @@ impl Dispatcher {
               Ok(true)
             })?;
             if took_fast {
-              let status = param_expansion_status.unwrap_or(old_status);
+              let status = if matches!(behavior, AssignBehavior::Set) {
+                // Assignment-only command: exit status is the last command
+                // substitution's status (or 0), not the pre-assignment status.
+                param_expansion_status.unwrap_or_else(|| last_cmdsub_status().unwrap_or(0))
+              } else {
+                param_expansion_status.unwrap_or(old_status)
+              };
 
               Shed::set_status(status);
               continue;
@@ -1938,7 +1957,13 @@ impl Dispatcher {
         }
       }
 
-      let status = param_expansion_status.unwrap_or(old_status);
+      let status = if matches!(behavior, AssignBehavior::Set) {
+        // Assignment-only command: exit status is the last command
+        // substitution's status (or 0), not the pre-assignment status.
+        param_expansion_status.unwrap_or_else(|| last_cmdsub_status().unwrap_or(0))
+      } else {
+        param_expansion_status.unwrap_or(old_status)
+      };
       Shed::set_status(status);
 
       if matches!(behavior, AssignBehavior::Export) {
@@ -2102,6 +2127,7 @@ pub fn check_err(
 }
 #[cfg(test)]
 mod tests {
+  use crate::assert_status_eq;
   use crate::state;
   use crate::tests::testutil::{TestGuard, test_input};
 
@@ -2821,6 +2847,72 @@ mod tests {
     let _g = TestGuard::new();
     test_input(r#"ml=$(printf 'a\nb\nc')"#).unwrap();
     assert_eq!(var!("ml"), "a\nb\nc");
+  }
+
+  // ─── Assignment exit status (POSIX §2.9.1) ─────────────────────────
+  // An assignment-only command's exit status is the status of the last
+  // command substitution performed, or 0 if there were none. The prior
+  // command's status must NOT leak through.
+
+  #[test]
+  fn assign_only_status_is_zero_with_no_cmdsub() {
+    let _g = TestGuard::new();
+    test_input("false; r=hi").unwrap();
+    assert_status_eq!(0);
+  }
+
+  #[test]
+  fn assign_only_status_zero_does_not_leak_after_success() {
+    let _g = TestGuard::new();
+    test_input("true; r=hi").unwrap();
+    assert_status_eq!(0);
+  }
+
+  #[test]
+  fn assign_only_status_reflects_failing_cmdsub() {
+    let _g = TestGuard::new();
+    test_input(r#"r=$(false)"#).unwrap();
+    assert_status_eq!(1);
+  }
+
+  #[test]
+  fn assign_only_status_reflects_failing_cmdsub_after_failure() {
+    // The prior `false` must not be what sets the status; the cmdsub does.
+    let _g = TestGuard::new();
+    test_input(r#"false; r=$(false)"#).unwrap();
+    assert_status_eq!(1);
+  }
+
+  #[test]
+  fn assign_only_status_reflects_succeeding_cmdsub_after_failure() {
+    // Key zoxide case: a failing condition before the assignment must not
+    // leak through and make a succeeding cmdsub look like it failed.
+    let _g = TestGuard::new();
+    test_input(r#"false; r=$(true)"#).unwrap();
+    assert_status_eq!(0);
+  }
+
+  #[test]
+  fn assign_only_status_is_last_cmdsub_across_multiple() {
+    let _g = TestGuard::new();
+    test_input(r#"r=$(false) s=$(true)"#).unwrap();
+    assert_status_eq!(0);
+  }
+
+  #[test]
+  fn assign_only_status_is_last_cmdsub_failing() {
+    let _g = TestGuard::new();
+    test_input(r#"r=$(true) s=$(false)"#).unwrap();
+    assert_status_eq!(1);
+  }
+
+  #[test]
+  fn assign_only_status_is_last_cmdsub_then_literal() {
+    // A trailing literal assignment doesn't reset the status; the last
+    // cmdsub's status wins.
+    let _g = TestGuard::new();
+    test_input(r#"r=$(false) s=hello"#).unwrap();
+    assert_status_eq!(1);
   }
 
   // ─── PlusEq on strings ──────────────────────────────────────────────

--- a/src/expand/mod.rs
+++ b/src/expand/mod.rs
@@ -5,7 +5,7 @@ mod escape;
 pub(super) mod markers;
 mod param;
 mod prompt;
-mod subshell;
+pub(crate) mod subshell;
 mod util;
 mod var;
 

--- a/src/expand/subshell.rs
+++ b/src/expand/subshell.rs
@@ -96,6 +96,31 @@ pub fn expand_proc_sub(raw: &str, is_input: bool) -> ShResult<String> {
   }
 }
 
+thread_local! {
+  /// Exit status of the most recently performed command substitution, set by
+  /// `expand_cmd_sub`/`internal_cmd_sub`. Consumed by `set_assignments` to
+  /// implement the POSIX rule that an assignment-only command's exit status is
+  /// the last command substitution's status (or 0 if there were none).
+  static LAST_CMDSUB_STATUS: std::cell::Cell<Option<i32>> =
+    const { std::cell::Cell::new(None) };
+}
+
+/// Record the exit status of a command substitution as it completes.
+pub(crate) fn set_last_cmdsub_status(code: i32) {
+  LAST_CMDSUB_STATUS.with(|c| c.set(Some(code)));
+}
+
+/// Read the last command substitution's status without clearing it.
+pub(crate) fn last_cmdsub_status() -> Option<i32> {
+  LAST_CMDSUB_STATUS.with(std::cell::Cell::get)
+}
+
+/// Clear the recorded command-substitution status. Call at the start of an
+/// assignment-only command so the cell reflects only its own cmdsubs.
+pub(crate) fn reset_last_cmdsub_status() {
+  LAST_CMDSUB_STATUS.with(|c| c.set(None));
+}
+
 pub fn is_internal(raw: &str) -> bool {
   let mut parser = ParsedSrc::new(raw.into()).with_name("is_internal check".into());
 
@@ -124,6 +149,8 @@ pub fn internal_cmd_sub(raw: &str) -> ShResult<VarStr> {
 
     errln!("shed: command sub truncated (exceeded {size})");
   }
+
+  set_last_cmdsub_status(Shed::get_status());
 
   Ok(
     bytes_to_string(scope.into_buf())
@@ -204,6 +231,7 @@ pub fn expand_cmd_sub(raw: &str) -> ShResult<VarStr> {
             Shed::set_status(procio::SINK_TRUNCATED_STATUS);
             errln!("shed: command sub truncated (exceeded {size})");
           }
+          set_last_cmdsub_status(Shed::get_status());
           Ok(output.trim_end_matches('\n').into())
         }
         _ => Err(sherr!(InternalErr, "Command sub failed")),


### PR DESCRIPTION
An assignment-only command (e.g. `r=$(...)`) inherited the previous command's exit status instead of following POSIX $2.9.1: its status is the last command substitution's status, or 0 if there were none.

This broke zoxide's `z`/`cd` in interactive shedrc. zoxide's __zoxide_z runs in an else-branch (after a failed `if`), so $? is 1. It then does `r=$(zoxide query ...)` and chains `&& __zoxide_cd $r`. Because the assignment left $? at 1, the && short-circuited and the cd never ran — `z unipi` silently failed.

Track command-substitution status in a thread-local (set by expand_cmd_sub/internal_cmd_sub), reset it at the start of an assignment-only command, and have set_assignments derive $? from it for AssignBehavior::Set. Export behavior is unchanged.

Adds 8 regression tests covering the status rules (verified against bash).

Another problem I found when trying to make zoxide work (before I discovered zd), LLM analyzed and fixed, feel free to reject.